### PR TITLE
import mode supports export to plain-text

### DIFF
--- a/bittyband/exportly.py
+++ b/bittyband/exportly.py
@@ -157,7 +157,7 @@ class LilypondFile:
             if isinstance(self.lyrics[0], str):
                 result.append("words = {")
                 result.append('%    \\set stanza = #"1. "')
-                for lne in self.lyrics[idx]:
+                for lne in self.lyrics:
                     result.append('    {}'.format(lne))
                 result.append("}")
                 result.append("")
@@ -415,7 +415,7 @@ def number_suffix(idx, totl):
             ret.append(c)
     return "".join(ret)
 
-def quote_as_needed(self, text):
+def quote_as_needed(text):
     if text.isalpha():
         return text
     return '"{}"'.format(text.replace("\\","\\\\").replace('"', r'\"'))

--- a/bittyband/exporttxt.py
+++ b/bittyband/exporttxt.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+class ExportTxt:
+    filename = None
+
+    def __init__(self, config, filenm):
+        self.filename = filenm
+        self.lines = []
+        self.trail = []
+        self.cur = []
+
+    def start(self):
+        pass
+
+    def end(self):
+        if len(self.cur) > 0:
+            self.lines.append("".join(self.cur))
+        if len(self.trail) > 0:
+            self.lines.extend(self.trail)
+        with self.filename.open("wt") as out:
+            out.write("\n".join(self.lines))
+
+    def new_track(self, *, copyright = None, tagline = None, poet=None,
+                  title, filename = None, **kwargs):
+        if len(self.trail) > 0:
+            self.lines.extend(self.trail)
+        self.trail = []
+
+        if len(self.lines) > 0:
+            self.lines.append("")
+            if title is None:
+                self.lines.append("----")
+                self.lines.append("")
+
+        if title is not None:
+            self.lines.append(title)
+            self.lines.append("=" * len(title))
+            self.lines.append("")
+
+        if poet:
+            self.lines.append("By: {}".format(poet))
+            self.lines.append("")
+
+        if copyright:
+            self.trail.append(copyright)
+        if tagline:
+            self.trail.append(tagline)
+        if len(self.trail) > 0:
+            self.trail.insert(0, "")
+
+    def unknown_track(self):
+        if len(self.lines) > 0:
+            self.lines.append("")
+
+        title = "Unknown Track"
+        self.lines.append(title)
+        self.lines.append("=" * len(title))
+        self.lines.append("")
+
+    def player(self):
+        pass
+
+    def sync_comment(self, cmt):
+        pass
+
+    def feed_comment(self, cmt, channel=None):
+        pass
+
+    def feed_time(self, nu, de):
+        pass
+
+    def feed_other(self, cmd, channel=None):
+        pass
+
+    def feed_lyric(self, lyric):
+        if lyric is None or lyric == "":
+            return
+        lyric = str(lyric)
+        if lyric.startswith("/"):
+            self.lines.append("".join(self.cur))
+            self.cur = []
+            lyric = lyric[1:]
+        elif lyric.startswith("\\"):
+            self.lines.append("".join(self.cur))
+            self.lines.append("")
+            self.cur = []
+            lyric = lyric[1:]
+        needSpace = False
+        for lyr in lyric.replace("~"," ").split():
+            if lyr == "" or lyr == "_":
+                continue
+            if lyr == "--":
+                needSpace = False
+                continue
+            if needSpace:
+                self.cur.append(" ")
+            else:
+                needSpace = True
+            self.cur.append(lyr)
+        if needSpace:
+            self.cur.append(" ")
+
+    def feed_midi(self, *what, ui=None, abbr=None, channel=None, time=None):
+        pass

--- a/bittyband/jamlister.py
+++ b/bittyband/jamlister.py
@@ -77,7 +77,7 @@ class JamLister:
         lister.register_key(self._do_export_midi, "M", "m", arg="?str",
                             prompt="Export to MIDI (^G to cancel; ENTER to name based on segment.]",
                             description="Export to MIDI")
-        lister.register_key(self._do_export_lily, "L", "l", arg="?str",
+        lister.register_key(self._do_export_lily, "Y", "y", "L", "l", arg="?str",
                             prompt="Export to Lilypond (^G to cancel; ENTER to name based on segment.]",
                             description="Export to Lilypond file")
 
@@ -114,7 +114,8 @@ class JamLister:
 
     def export_midi(self, what, output):
         exporter = ExportMidi(self.config, output)
-        cmds = Commands(self.config, exporter, None, BackgroundNull())
+        cmds = Commands(self.config)
+        cmds.wire(push_player=exporter, metronome=BackgroundNull())
         exporter.start()
         cmds.play(self.get(what), realtime=False)
         exporter.end()
@@ -122,7 +123,7 @@ class JamLister:
     def export_ly(self, what, output, title=""):
         exporter = ExportLy(self.config, output, title=title)
         cmds = Commands(self.config)
-        cmds.configure(exporter, None, BackgroundNull())
+        cmds.wire(push_player=exporter, metronome=BackgroundNull())
         exporter.start()
         cmds.play(self.get(what), realtime=False)
         exporter.end()

--- a/bittyband/uicurses/__init__.py
+++ b/bittyband/uicurses/__init__.py
@@ -61,8 +61,11 @@ class UiCurses:
                 ret = None
             finally:
                 self.stdscrs[-1].nodelay(0)
-        if len(ret) == 1 and ord(ret) < 0x20:
-            ret = "^{}".format(chr(ord(ret) + ord('@')))
+        if len(ret) == 1:
+            if ord(ret) < 0x20:
+                ret = "^{}".format(chr(ord(ret) + ord('@')))
+            elif ord(ret) == 0x7f:
+                ret = "^?"
         return ret
 
     def _switch(self, stdscr, generator, logic=None):

--- a/bittyband/uicurses/spreader.py
+++ b/bittyband/uicurses/spreader.py
@@ -18,9 +18,10 @@ class Spreader(GenericLister):
     def get_key(self):
         key = None
         while key is None:
-            key = self.ui.get_key(timeout=0.01)
-            if self.idle_cmd is not None:
-                self.idle_cmd()
+            key = self.ui.get_key(timeout=0.5)
+            if key is None:
+                if self.idle_cmd is not None:
+                    self.idle_cmd()
         return key
 
     def register_idle(self, idle_cmd):
@@ -39,6 +40,8 @@ class Spreader(GenericLister):
         self.exit_func = func
 
     def display_time(self, text = None, *, no_refresh=False):
+        if text == self.time and not no_refresh:
+            return
         max_y, max_x = self.stdscr.getmaxyx()
         if text is not None:
             self.time = "[{}]".format(text)
@@ -49,6 +52,8 @@ class Spreader(GenericLister):
             self.stdscr.refresh()
 
     def display_line(self, text = None, *, no_refresh=False):
+        if text == self.line and not no_refresh:
+            return
         max_y, max_x = self.stdscr.getmaxyx()
         if text is not None:
             self.line = "@{}".format(text)
@@ -63,3 +68,4 @@ class Spreader(GenericLister):
         if self.exit_func is not None:
             self.exit_func()
         return False
+


### PR DESCRIPTION
We're kind of wiggling around the various export formats for the import mode. Right now the export to Lilypond and MIDI processes have commands in the UI, but are broken.

Export to text, however, works quite nicely.

This starts the use of "\" for a stanza break and "/" for a line break, following on the use of those characters in the KAR format. This works for the text-export, and there's a command to toggle that setting without editing the lyric, going to the beginning of the line and changing it. (It's the `/` command.)

The csvplayer has some concept of exporting, but appears to only properly export the lyrics and metadata. (So a little more work to be done there.)

The `genericlister` and the `spreader` based upon it, now use their own `FieldReader` class to read input, allowing us to perform our normal idle call. The up and down keys jump by word, which comes in handy for some lyric use-cases. The new class also allows us to update existing data, instead of just requiring a whole new line to be entered. Lyrics and Marks support this.

closes #37