### PR TITLE
minor fixes

### DIFF
--- a/bittyband/uicurses/genericlister.py
+++ b/bittyband/uicurses/genericlister.py
@@ -22,6 +22,7 @@ class FieldReader:
         self.x2 = x2
         self.cursor = x1
         self.next_of_kind = False
+        self.apply_change = False
 
     def move(self, x = None):
         if x is not None:
@@ -70,6 +71,9 @@ class FieldReader:
             return False
         elif key == "^I":
             self.next_of_kind = True
+            return False
+        elif key == "^R":
+            self.apply_change = True
             return False
         elif key == "^K":
             self.data = self.data[:self.cursor - self.x1]
@@ -139,6 +143,7 @@ class GenericLister:
         self.ui = None
         self.invalidate = False
         self.next_of_kind = False
+        self.apply_change = False
 
     def wire(self, *, logic, ui, **kwargs):
         self.ui = ui
@@ -212,6 +217,7 @@ class GenericLister:
         fr = FieldReader(self, self.stdscr, max_y - 1, 0, max_x)
         s = fr.get(initial)
         self.next_of_kind = fr.next_of_kind
+        self.apply_change = fr.apply_change
         self.stdscr.hline(max_y - 2, 0, "=", max_x)
         self.stdscr.addstr(" ")
         self.stdscr.move(max_y - 1, 0)
@@ -284,7 +290,7 @@ class GenericLister:
                 elif entry.arg == "?str":
                     initial = ""
                     self.next_of_kind = True
-                    while self.next_of_kind:
+                    while self.next_of_kind or self.apply_change:
                         if entry.query:
                             initial = entry.function(None, line=-self.active)
                         s = self.read_string(entry.prompt, initial=initial)

--- a/bittyband/utils/cmdutils.py
+++ b/bittyband/utils/cmdutils.py
@@ -117,8 +117,15 @@ def parse_sequence(pad_sequence, chord_map):
     seq = pad_sequence.split("-")
     # pad_sequence = I-vi-IV-V
     for s in seq:
+        octave = 0
+        while s.endswith("'"):
+            octave += 12
+            s = s[:-1]
+        while s.endswith(","):
+            octave -= 12
+            s = s[:-1]
         if s in chord_map:
-            ret.append(chord_map[s])
+            ret.append([x + octave for x in chord_map[s]])
         else:
             raise ConfigError("Unrecognized chord: {}".format(s))
     return ret
@@ -138,9 +145,17 @@ def add_for_scale(box, suffix, notes, scale, key_note):
         for o in notes.split():
             if o == "":
                 continue
+            octave = 0
+            while o.endswith("'"):
+                octave += 12
+                o = o[:-1]
+            while o.endswith(","):
+                octave -= 12
+                o = o[:-1]
             ival = _interval_conversion.get(o)
             if ival is None:
                 raise ConfigError("Unknown interval: " + o)
+            ival += octave
             chord.append(note + ival)
         box[str(n + 1) + suffix] = chord
         box[_roman[n] + suffix] = chord
@@ -176,9 +191,17 @@ def add_override(box, stompers, notes, scale, key_note):
         for o in notes.split():
             if o == "":
                 continue
+            octave = 0
+            while o.endswith("'"):
+                octave += 12
+                o = o[:-1]
+            while o.endswith(","):
+                octave -= 12
+                o = o[:-1]
             ival = _interval_conversion.get(o)
             if ival is None:
                 raise ConfigError("Unknown interval: " + o)
+            ival += octave
             chord.append(note + ival)
         box[stomp] = chord
 

--- a/bittyband/utils/time.py
+++ b/bittyband/utils/time.py
@@ -5,7 +5,7 @@ __all__ = ["human_duration", "reasonable_time", "from_human_duration"]
 import time
 
 def from_human_duration(code):
-    if code is None or isinstance(code, int) or isinstance(code,float):
+    if code is None or isinstance(code, int) or isinstance(code,float) or code == "":
         return code
     splits = code.split(":")
     ret = 0


### PR DESCRIPTION
Track "0.0" is used for the initial data -- if present. (Instead of always starting with -1 from the "no track here" logic.)

There were some cases where an empty string for a string-based command would kill the app.

Nudge doesn't work at the top/bottom, so it presents a message about this.

Nudging plays a trick on the current line to cause the "play current line" logic to refresh. This makes it _much_ nicer.

The default song chord progression wasn't being set properly, so when it was changed by the user, it was ignored.

We have an "apply-change" command when getting a string. (^R) This is to accompany the "next-in-kind" (TAB) command. While "next-in-kind" does the same command on the line below it, "apply-change" redoes the command on the current line. (Not sure it will be super-useful after I was playing with it, but it works.)

Here's something new: chord progressions can fiddle with the octave using the standard "'" and "," characters as suffixes. This means we can tweak just the octave in an otherwise standard Nashville chord progression.