### PR TITLE
more tweaks

### DIFF
--- a/bittyband/config.py
+++ b/bittyband/config.py
@@ -19,8 +19,6 @@ config = ConfigParser(inline_comment_prefixes=None)
 def parse(argv):
     global config
     global parser
-    if len(argv) == 0:
-        argv = ["gui"]
     args = parser.parse_args(argv)
     if hasattr(args, "func"):
         if args.func(args):
@@ -31,7 +29,8 @@ def parse(argv):
         if args.mode == "importer":
             config["instance"]["import-file"] = args.import_file
     else:
-        config["instance"]["mode"] = "gui"
+        parser.parse_args(["-h"])
+        sys.exit(0)
     return config
 
 
@@ -299,7 +298,6 @@ parser.add_argument("-p", "--project", metavar="PROJ",
                     help="Specify a project or project location other than the current directory.")
 parser.add_argument("--midiport", metavar="PORT",
                     help="Specify an explicit MIDI port to use. (Default: first available.)")
-# parser.add_argument("-u", "--user", help="ignore project-specific config file")
 subparsers = parser.add_subparsers(title="Actions", help="Action to take")
 parser_create = subparsers.add_parser("create", description="Create a new project")
 parser_create.add_argument("project", help="Name of project directory to create.")

--- a/bittyband/exportly.py
+++ b/bittyband/exportly.py
@@ -350,7 +350,14 @@ class ExportLy:
         elif lyric.startswith("\\"):
             self.lily.lyrics.append("\n\n")
             lyric = lyric[1:]
-        self.lily.lyrics.append(quote_as_needed(lyric))
+        if lyric.endswith(" --"):
+            self.lily.lyrics.append(quote_as_needed(lyric[:-3]))
+            self.lily.lyrics.append("--")
+        elif lyric.endswith(" __"):
+            self.lily.lyrics.append(quote_as_needed(lyric[:-3]))
+            self.lily.lyrics.append("__")
+        else:
+            self.lily.lyrics.append(quote_as_needed(lyric))
 
     def feed_midi(self, *what, abbr=None, channel=None, time=None):
         if len(what) == 0:

--- a/bittyband/exportmidi.py
+++ b/bittyband/exportmidi.py
@@ -11,15 +11,10 @@ from datetime import datetime, timedelta
 from mido import Message, MidiFile, MidiTrack
 
 class ExportMidi:
-    track = None
-    filenm = None
-
     def __init__(self, config, filenm):
+        self.track = None
         self.filenm = filenm
-        self.reconfigure(config)
-
-    def reconfigure(self, config):
-        pass
+        self.midifile = None
 
     def new_track(self, **kwargs):
         pass

--- a/bittyband/exporttxt.py
+++ b/bittyband/exporttxt.py
@@ -19,14 +19,21 @@ class ExportTxt:
             self.lines.extend(self.trail)
         with self.filename.open("wt") as out:
             out.write("\n".join(self.lines))
+            out.write("\n")
 
     def new_track(self, *, copyright = None, tagline = None, poet=None,
                   title, filename = None, **kwargs):
+        if len(self.cur) > 0:
+            self.lines.append("".join(self.cur))
+            self.cur = []
+
         if len(self.trail) > 0:
             self.lines.extend(self.trail)
         self.trail = []
 
         if len(self.lines) > 0:
+            if self.lines and self.lines[-1] != "":
+                self.lines.append("")
             self.lines.append("")
             if title is None:
                 self.lines.append("----")
@@ -49,13 +56,24 @@ class ExportTxt:
             self.trail.insert(0, "")
 
     def unknown_track(self):
-        if len(self.lines) > 0:
-            self.lines.append("")
+        if len(self.cur) > 0:
+            self.lines.append("".join(self.cur))
+            self.cur = []
 
         title = "Unknown Track"
-        self.lines.append(title)
-        self.lines.append("=" * len(title))
-        self.lines.append("")
+
+        if len(self.lines) > 0:
+            if self.lines and self.lines[-1] != "":
+                self.lines.append("")
+            self.lines.append("")
+            if title is None:
+                self.lines.append("----")
+                self.lines.append("")
+
+        if title is not None:
+            self.lines.append(title)
+            self.lines.append("=" * len(title))
+            self.lines.append("")
 
     def player(self):
         pass
@@ -77,12 +95,15 @@ class ExportTxt:
             return
         lyric = str(lyric)
         if lyric.startswith("/"):
-            self.lines.append("".join(self.cur))
+            if self.cur:
+                self.lines.append("".join(self.cur))
             self.cur = []
             lyric = lyric[1:]
         elif lyric.startswith("\\"):
-            self.lines.append("".join(self.cur))
-            self.lines.append("")
+            if self.cur:
+                self.lines.append("".join(self.cur))
+            if self.lines and self.lines[-1] != "":
+                self.lines.append("")
             self.cur = []
             lyric = lyric[1:]
         needSpace = False


### PR DESCRIPTION
Don't touch the file if we don't do anything. This adds an explicit "changed" state. This seemed important as we now sort the import list by timestamp (most recent on top), and we didn't want to touch a file when we just wanted to listen to it.

The app no longer defaults to jam mode. It'll produce help text if you don't specify the mode.

Lilypond export has been tweaked to deal with trailing " --" and " __" which would be inserted on the end of a note's lyric. Previously it was (wrongly) quoting it.

Text export has been cleaned up. "Next Screen" markers leave an empty line, but can't accidentally produce multiple empty lines. A trailing untracked entry no longer messes up the last line of text. Tracks are separated with two empty lines.

The Import Lister now supports export of MIDI, Lilypond, and plain-text of the items in the list. It also uses the basename for the default filename, instead of defaulting to "export". Since there weren't a lot of commands defined for the import lister, we've bound both the standard Importer's commands, as well as the more logical initial letter.