### PR TITLE
some important fixes

### DIFF
--- a/bittyband/importer/__init__.py
+++ b/bittyband/importer/__init__.py
@@ -1001,9 +1001,11 @@ class Importer:
         padout=max_len - 23
         marklen = int(padout // 3)
         lyrlen = int(padout * 2 // 3)
+        loc = human_duration(datum["location"], floor=3)
+        lyrlen -= len(loc) - 9
         return "{human_time} {note_ui:5.5} {lyric:{lyrlen}.{lyrlen}} {chord_ui: >3.3} {track_ui: >3.3} {mark:{marklen}.{marklen}}".format(
             marklen=marklen, lyrlen=lyrlen,
-            human_time=human_duration(datum["location"], floor=3), **datum)
+            human_time=loc, **datum)
 
     def get_order(self):
         return self.order

--- a/bittyband/uicurses/genericlister.py
+++ b/bittyband/uicurses/genericlister.py
@@ -94,15 +94,16 @@ class FieldReader:
         elif key in ("^P", "KEY_UP"):
             buf = "".join(self.data)
             i = self.cursor - self.x1
-            if i >= len(buf):
-                i = len(buf) - 1
-            if buf[i].isspace():
-                while i >= 0 and buf[i].isspace():
+            if i > 0:
+                if i >= len(buf):
+                    i = len(buf) - 1
+                if buf[i].isspace():
+                    while i >= 0 and buf[i].isspace():
+                        i -= 1
+                while i >= 0 and not buf[i].isspace():
                     i -= 1
-            while i >= 0 and not buf[i].isspace():
-                i -= 1
-            self.move(i + self.x1)
-            self.stdscr.refresh()
+                self.move(i + self.x1)
+                self.stdscr.refresh()
         return True
 
     def refresh(self):


### PR DESCRIPTION

When audio files were over an hour long, it messed with the importer display. That's been fixed.

Key_Up without lyrics now won't kill the app anymore.

The Import Lister now supports "D" to delete the audio file. It doesn't actually delete it, but there's no in-app method to recover it. (You need to manually tweak the meta file.) This helps when dealing with a lot of audio files, and some of them have been fully processed.