### PR TITLE
various important fixes

### DIFF
--- a/bittyband/app.py
+++ b/bittyband/app.py
@@ -8,7 +8,7 @@ from .player import PushButtonPlayer
 from .ui import get_ui
 from .cmdrecorder import CommandRecorder
 from .jamlister import JamLister
-from .bgplayer import BackgroundDrums
+from .bgplayer import BackgroundDrums, BackgroundNull
 from .importer import Importer
 from .importlister import ImportLister
 
@@ -17,8 +17,8 @@ def app(config):
     wiring = {}
     wiring["ui"] = ui = ui_maker(config)
     wiring["push_player"] = PushButtonPlayer(config)
-    wiring["metronome"] = BackgroundDrums(config)
     wiring["push_commands"] = Commands(config)
+    wiring["metronome"] = BackgroundDrums(config)
 
     need_for_mode = []
     mode = lambda: True
@@ -29,6 +29,7 @@ def app(config):
 
     elif config["instance"]["mode"] == "list":
         wiring["jam_lister"] = JamLister(config)
+        wiring["metronome"] = BackgroundNull(config)
         need_for_mode = ["push_player", "metronome"]
         mode = ui.start_list
 

--- a/bittyband/uicurses/genericlister.py
+++ b/bittyband/uicurses/genericlister.py
@@ -255,6 +255,16 @@ class GenericLister:
         self.move_to(self.active + 1)
         return False
 
+    def _page_up_cmd(self, line):
+        max_y = self.stdscr.getmaxyx()[0]
+        self.move_to(self.active + int(max_y / 2))
+        return False
+
+    def _page_down_cmd(self, line):
+        max_y = self.stdscr.getmaxyx()[0]
+        self.move_to(self.active - int(max_y / 2))
+        return False
+
     def _help_cmd(self, line):
         return True
 
@@ -269,6 +279,10 @@ class GenericLister:
                           description="Move down a row")
         self.register_key(self._up_cmd, "KEY_UP",
                           description="Move up a row")
+        self.register_key(self._page_down_cmd, "KEY_SR",
+                          description="Move down several row")
+        self.register_key(self._page_up_cmd, "KEY_SF",
+                          description="Move up several row")
         self.register_key(self._refresh_cmd, "^L", "^R",
                           description="Refresh the window")
         self.register_key(self._help_cmd, "?",


### PR DESCRIPTION
* add beat-repeat with the "B" key

Is there an established rhythm for a section of the file? Leverage it.

12 x 120bpm -- create 12 1-beat locations at 120bpm
6 x 2@120bpm -- create 6 2-beat locations at 120bpm
6 beats -- between row and row+1 is a beat, repeat that 6 times.

* Using the "bpm" key to assign key slots now accepts multipliers for the BPM, so you can say you want half notes for 142 BPM instead of quarter notes.

* We now have explicit commands to swap line contents with the line below ("w") and the line above ("W") when in import mode.

* Since the "lily_key" isn't derived from the standard "key", we now use the same default for the "key" that we use elsewhere.

* Speaking of which, we now default to G Major instead of C Major.

* All of the lister-type UIs now have page-up and page-down using shift-up and shift-down. We should probably actually support the page-up and page-down keys at some point, but Macs don't have them and that's what I'm working on.

* We don't currently export the drum/metronome track in the jamlister, so we now no longer play it, too.

* Drum velocity is significantly lowered, as it is just a metronome for now. The background player had some major refactory, as it wasn't wanting to stop/start previously.

* On a related note, the pad volume for the jam-mode was reset to normal levels.

* There was a problem with the preset not being specified in jam file when it was triggered from a mark-based event. It turned out, we just weren't writing it. Now we do.

* lilypond now produces expected results

It's now possible to take an MP3 of silence in to the import tool, mark it up according to 100 BPM, give it notes and chords and lyrics and produce correct sheet music on the other side.

This means while the fuzzy logic may still be a bit fuzzy, the basic logic is sound.

closes #60
